### PR TITLE
Check that this update does not break reverse deps

### DIFF
--- a/fedora-pr-review-guide.md
+++ b/fedora-pr-review-guide.md
@@ -9,6 +9,7 @@ Copy & paste to your PR review.
 ```
 - [ ] PR solves the issue it claims to address (updates the package, solves a bug, etc.)
 - [ ] Resulting RPM package is installable on the destination Fedora release
+- [ ] No dependent RPM packages will stop being installable when the PR is merged and built
 - [ ] PR is tested sufficiently and the test results are OK (green CI, impact check issues addressed)
 - [ ] PR is open against all relevant Fedora releases
 - [ ] (If PR is open against more Fedora releases) branches don't diverge unnecessarily


### PR DESCRIPTION
This is already described near the impact check,
but I went ahead and submitted this as a checkbox, because it's one of the things we often forget to check.